### PR TITLE
[#3] default service address to agent if not specified

### DIFF
--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -77,8 +77,12 @@ func (c *consulResolver) query(opts *consul.QueryOptions) ([]resolver.Address, u
 
 	result := make([]resolver.Address, 0, len(entries))
 	for _, e := range entries {
+	        addr := e.Service.Address
+	        if addr == "" {
+	               addr = e.Node.Address
+                }
 		result = append(result, resolver.Address{
-			Addr:       fmt.Sprintf("%s:%d", e.Service.Address, e.Service.Port),
+			Addr:       fmt.Sprintf("%s:%d", addr, e.Service.Port),
 			ServerName: e.Service.ID,
 		})
 	}


### PR DESCRIPTION
This address #3. If the service address is an empty string, then the agent address is used instead.
