### PR TITLE
fix: resolver delayed next query on fast empty responses unnecessarily

### DIFF
--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -150,7 +150,6 @@ func sortAddresses(addrs []resolver.Address) {
 
 func (c *consulResolver) watcher() {
 	var lastReportedAddrs []resolver.Address
-	var lastWaitIndex uint64
 
 	opts := (&consul.QueryOptions{}).WithContext(c.ctx)
 
@@ -161,9 +160,10 @@ func (c *consulResolver) watcher() {
 			var addrs []resolver.Address
 			var err error
 
+			lastWaitIndex := opts.WaitIndex
+
 			queryStartTime := time.Now()
 			addrs, opts.WaitIndex, err = c.query(opts)
-			lastWaitIndex = opts.WaitIndex
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
 					return


### PR DESCRIPTION
When consul returned no addresses 2x times in a row but different waitIndices
the next query was delayed for 50ms.
The following query should only be delayed if the same addresses and same
WaitIndex is returned then in the previous call.

The cause was that lastWaitIndex was set to the new waitIndex after the query
was returned, before the check.