### PR TITLE
fix: grpc calls block forever when service entry does not exist in consul

### DIFF
--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -182,9 +182,12 @@ func (c *consulResolver) watcher() {
 			// data newer then the passed opts.WaitIndex is available.
 			// We check if the returned addrs changed to not call
 			// cc.UpdateState() unnecessary for unchanged addresses.
-			if (len(addrs) == 0 && len(lastReportedAddrs) == 0) ||
-				reflect.DeepEqual(addrs, lastReportedAddrs) {
-
+			// If the service does not exist, an empty addrs slice
+			// is returned. If we never reported any resolved
+			// addresses (addrs is nil), we have to report an empty
+			// set of resolved addresses. It informs the grpc-balancer that resolution is not
+			// in progress anymore and grpc calls can failFast.
+			if reflect.DeepEqual(addrs, lastReportedAddrs) {
 				// If the consul server responds with
 				// the same data then in the last
 				// query in less then 50ms, we sleep a

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -283,7 +283,7 @@ func TestResolveNewAddressOnlyCalledOnChange(t *testing.T) {
 	defer cleanup()
 
 	service := []*consul.ServiceEntry{
-		&consul.ServiceEntry{
+		{
 			Service: &consul.AgentService{
 				Address: "localhost",
 				Port:    5678,
@@ -330,7 +330,7 @@ func TestResolveAddrChange(t *testing.T) {
 	defer cleanup()
 
 	services1 := []*consul.ServiceEntry{
-		&consul.ServiceEntry{
+		{
 			Service: &consul.AgentService{
 				Address: "localhost",
 				Port:    5678,
@@ -339,20 +339,20 @@ func TestResolveAddrChange(t *testing.T) {
 	}
 
 	addrs1 := []*consul.AgentService{
-		&consul.AgentService{
+		{
 			Address: "localhost",
 			Port:    5678,
 		},
 	}
 
 	services2 := []*consul.ServiceEntry{
-		&consul.ServiceEntry{
+		{
 			Service: &consul.AgentService{
 				Address: "localhost",
 				Port:    5678,
 			},
 		},
-		&consul.ServiceEntry{
+		{
 			Service: &consul.AgentService{
 				Address: "remotehost",
 				Port:    12345,
@@ -361,7 +361,7 @@ func TestResolveAddrChange(t *testing.T) {
 	}
 
 	addrs2 := []*consul.AgentService{
-		&consul.AgentService{
+		{
 			Address: "localhost",
 			Port:    5678,
 		},
@@ -419,7 +419,7 @@ func TestResolveAddrChangesToUnresolvable(t *testing.T) {
 	defer cleanup()
 
 	services1 := []*consul.ServiceEntry{
-		&consul.ServiceEntry{
+		{
 			Service: &consul.AgentService{
 				Address: "localhost",
 				Port:    5678,
@@ -428,7 +428,7 @@ func TestResolveAddrChangesToUnresolvable(t *testing.T) {
 	}
 
 	addrs1 := []*consul.AgentService{
-		&consul.AgentService{
+		{
 			Address: "localhost",
 			Port:    5678,
 		},

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -119,6 +119,13 @@ func TestResolve(t *testing.T) {
 		},
 
 		{
+			name:           "emptyConsulResponseResolvestoEmptyAddrs",
+			target:         resolver.Target{Endpoint: "user-service"},
+			consulResponse: []*consul.ServiceEntry{},
+			resolverResult: []resolver.Address{},
+		},
+
+		{
 			name:   "UseAgentAddrIfServiceAddrEmpty",
 			target: resolver.Target{Endpoint: "user-service"},
 			consulResponse: []*consul.ServiceEntry{


### PR DESCRIPTION
        fix: grpc calls block forever when service entry does not exist in consul

        When no service entry in consul existed for the service that should be resolved,
        no result was reported to the ClientConn (UpdateState() wasn't called).
        This caused that the GRPC channel got stuck in CONNECTING state.
        When a GRPC call was done on the connection it was blocking forever because the
        channel was still trying to establish the connection.

        Calling UpdateState() with an empty set of addresses on the first try, when
        consul reported no addresses, transitions the channel state to
        TRANSIENT_FAILURE. This allows GRPC calls on the connection to fail with an
        UNAVAILABLE error.

-------------------------------------------------------------------------------

        replace reflect.DeepEqual() with addressesEqual() function

        Instead of using reflect.DeepEqual() implement and use a function to compare 2
        resolver.Address slices.
        The function is more specific and simple then reflect.DeepEqual() and therefore
        faster.

