### PR TITLE
Utilize url.URL when parsing the target url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The default for `<consul-server>` is `127.0.0.1:8500`.
 | scheme     | `http\|https`                   | http     | Establish connection to consul via http or https.                                                                                                                |
 | tags       | `<tag>,[,<tag>]...`             |          | Filter service by tags                                                                                                                                           |
 | health     | `healthy\|fallbackToUnhealthy`  | healthy  | `healthy` resolves only to services with a passing health status.<br>`fallbackToUnhealthy` resolves to unhealthy ones if none exist with passing healthy status. |
+| token      | `string`                        |          | Add X-Consul-Token header to requests in order to authenticate against ACL                                                                                       |
 
 ## Example
 

--- a/consul/builder_test.go
+++ b/consul/builder_test.go
@@ -23,14 +23,16 @@ func TestParseEndpoint(t *testing.T) {
 		wantTags         []string
 		wantErr          bool
 		wantHealthFilter healthFilter
+		wantToken        string
 	}{
 		{
-			mustParseURL(t, "consul://127.0.01:8500/user-service-rpc?scheme=https&tags=primary,backup&health=healthy"),
+			mustParseURL(t, "consul://127.0.01:8500/user-service-rpc?scheme=https&tags=primary,backup&health=healthy&token=Olj1SIrsGXB_1orYMT71RVCs6FYwGZ_l"),
 			"user-service-rpc",
 			"https",
 			[]string{"primary", "backup"},
 			false,
 			healthFilterOnlyHealthy,
+			"Olj1SIrsGXB_1orYMT71RVCs6FYwGZ_l",
 		},
 
 		{
@@ -40,6 +42,7 @@ func TestParseEndpoint(t *testing.T) {
 			[]string{"pri-mary", "backup"},
 			false,
 			healthFilterFallbackToUnhealthy,
+			"",
 		},
 
 		{
@@ -49,6 +52,7 @@ func TestParseEndpoint(t *testing.T) {
 			nil,
 			false,
 			healthFilterOnlyHealthy,
+			"",
 		},
 
 		{
@@ -58,6 +62,7 @@ func TestParseEndpoint(t *testing.T) {
 			nil,
 			true,
 			healthFilterUndefined,
+			"",
 		},
 
 		{
@@ -67,6 +72,7 @@ func TestParseEndpoint(t *testing.T) {
 			nil,
 			true,
 			healthFilterUndefined,
+			"",
 		},
 
 		{
@@ -76,6 +82,7 @@ func TestParseEndpoint(t *testing.T) {
 			nil,
 			true,
 			healthFilterUndefined,
+			"",
 		},
 
 		{
@@ -85,6 +92,7 @@ func TestParseEndpoint(t *testing.T) {
 			nil,
 			true,
 			healthFilterUndefined,
+			"",
 		},
 
 		{
@@ -94,6 +102,7 @@ func TestParseEndpoint(t *testing.T) {
 			[]string{"secondary"},
 			false,
 			healthFilterFallbackToUnhealthy,
+			"",
 		},
 
 		{
@@ -103,12 +112,13 @@ func TestParseEndpoint(t *testing.T) {
 			nil,
 			true,
 			healthFilterUndefined,
+			"",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.endpoint.String(), func(t *testing.T) {
-			serviceName, scheme, tags, healthFilter, err := parseEndpoint(tt.endpoint)
+			serviceName, scheme, tags, healthFilter, token, err := parseEndpoint(tt.endpoint)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseEndpoint() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -128,6 +138,10 @@ func TestParseEndpoint(t *testing.T) {
 
 			if healthFilter != tt.wantHealthFilter {
 				t.Errorf("parseEndpoint() gotHealthFilter = %v, want %v", healthFilter, tt.wantHealthFilter)
+			}
+
+			if !reflect.DeepEqual(tt.wantToken, token) {
+				t.Errorf("parseEndpoint() gotToken = %+v, want %+v", token, tt.wantToken)
 			}
 		})
 	}

--- a/consul/builder_test.go
+++ b/consul/builder_test.go
@@ -140,8 +140,8 @@ func TestParseEndpoint(t *testing.T) {
 				t.Errorf("parseEndpoint() gotHealthFilter = %v, want %v", healthFilter, tt.wantHealthFilter)
 			}
 
-			if !reflect.DeepEqual(tt.wantToken, token) {
-				t.Errorf("parseEndpoint() gotToken = %+v, want %+v", token, tt.wantToken)
+			if token != tt.wantToken {
+				t.Errorf("parseEndpoint() gotToken = %s, want %s", token, tt.wantToken)
 			}
 		})
 	}

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -54,10 +54,12 @@ func newConsulResolver(
 	scheme, consulAddr, consulService string,
 	tags []string,
 	healthFilter healthFilter,
+	token string,
 ) (*consulResolver, error) {
 	cfg := consul.Config{
 		Address: consulAddr,
 		Scheme:  scheme,
+		Token:   token,
 	}
 
 	health, err := consulCreateHealthClientFn(&cfg)


### PR DESCRIPTION
Since grpc-go 1.42.0  resolver.Target contains an url.URL struct. Use the utility methods of the URL struct to retrieve the url path and parse the query-parameter, instead of implement it on our own.

The behavior when an option is defined multiple in a query string is now also documented in the package doc and tested in a unit-test.

Closes #21 