### PR TITLE
improve consul package godoc

### DIFF
--- a/consul/builder.go
+++ b/consul/builder.go
@@ -1,37 +1,37 @@
-package consul
-
 // Package consul implements a GRPC resolver for consul service discovery.
 // The resolver queries consul for healthy services with a specified name.
-// Blocking Consul queries
-// (https://www.consul.io/api/index.html#blocking-queries) are used to monitor
-// consul for changes.
+// [Blocking Consul queries] are used to monitor Consul for changes.
 //
 // To register the resolver with the GRPC-Go library run:
+//
 //	resolver.Register(consul.NewBuilder())
-// Afterwards it can be used by calling grpc.Dial() and passing an URI in the
-// following format: consul://[<consul-server>]/<serviceName>[?<OPT>[&<OPT>]]
-// where OPT:
-//  scheme=(http|https)			  - establish connection to consul via
-//  http or https
-//  tags=<tag>[,<tag>]...		  - filters the consul service by tags
-//  health=(healthy|fallbackToUnhealthy)  - filter services by their
-//					    health checks status.
-//					    fallbackToUnhealthy resolves to
-//					    unhealthy ones if no healthy ones
-//					    are available.
-//  token				  - Consul token used in API requests
-// Defaults:
-//            consul-server:		127.0.0.1:8500
-//            scheme:			http
-//            tags:			nil
-//            health:			healthy
-//            token:
-// Example: consul://localhost:1234/user-service?scheme=https&tags=primary,eu
-// Will connect to the consul server localhost:1234 via https and lookup the
-// address of the service with the name "user-service" and the tags "primary"
-// and "eu".
-// If an OPT is defined multiple times, only the value of the last occurrence is
-// used.
+//
+// Afterwards it can be used by calling [google.golang.org/grpc.Dial] and
+// passing an URL in the following format:
+//
+//	consul://[<consul-server>]/<serviceName>[?<OPT>[&<OPT>]...]
+//
+// When consul-server is not specified 127.0.0.1:8500 is used.
+//
+// OPT is one of:
+//
+//   - scheme=http|https specifies if the connection to Consul is established
+//     via HTTP or HTTPS. Default: http
+//   - tags=<tag>[,<tag>]... only resolves to instances that have the given
+//     tags. Default: empty
+//   - health=healthy|fallbackToUnhealthy filters Services by their health status.
+//     If set to "healthy", the service is only resolved to instances with
+//     passing health checks. If set to "fallbackToUnhealthy", the service
+//     resolves to all instances, if none with a passing status is available.
+//     Default: healthy
+//   - token=<string> includes the token in API-Requests to Consul.
+//
+// If an OPT is defined multiple times, only the value of the last occurrence
+// is used.
+//
+// [Blocking Consul queries]: https://developer.hashicorp.com/consul/api-docs/features/blocking
+package consul
+
 import (
 	"errors"
 	"fmt"


### PR DESCRIPTION
- move the godoc before the package stmt, otherwise it is not shown in the rendered version
- make use of godoc lists and references
- restructure the section explaining the options

needs to be merged after https://github.com/simplesurance/grpcconsulresolver/pull/22