### PR TITLE
Increase blocking query wait time from 5m to 10m

### DIFF
--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -57,9 +57,10 @@ func newConsulResolver(
 	token string,
 ) (*consulResolver, error) {
 	cfg := consul.Config{
-		Address: consulAddr,
-		Scheme:  scheme,
-		Token:   token,
+		Address:  consulAddr,
+		Scheme:   scheme,
+		Token:    token,
+		WaitTime: 10 * time.Minute,
 	}
 
 	health, err := consulCreateHealthClientFn(&cfg)


### PR DESCRIPTION
According to the Consul doc[^1], the default blocking query WaitTime is
configured at the agent, which defaults to 5m. The maximum WaitTime is 10m. Set
the WaitTime to the maximum when doing blocking queries.

When the WaitTime expired, the query returns, also if the watched catalog
entries have not changed.
Waiting longer means, less queries have to initiated unnecessary and returned
results have to be less often evaluated when they have not changed.

[^1]: https://developer.hashicorp.com/consul/api-docs/features/blocking