### PR TITLE
Reset WaitIndex when a smaller WaitIndex is returned

### DIFF
--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -193,6 +193,13 @@ func (c *consulResolver) watcher() {
 				break
 			}
 
+			if opts.WaitIndex < lastWaitIndex {
+				grpclog.Infof("grpcconsulresolver: consul responded with a smaller waitIndex (%d) then the previous one (%d), restarting blocking query loop",
+					opts.WaitIndex, lastWaitIndex)
+				opts.WaitIndex = 0
+				continue
+			}
+
 			sort.Slice(addrs, func(i, j int) bool {
 				return addrs[i].Addr < addrs[j].Addr
 			})


### PR DESCRIPTION
According to the Consul doc[^1], resolvers must handle the case that Consul returns a WaitIndex that was lower then the requested one, by doing another query with a WaitIndex of 0.
If this is not done, updates can be missed.

Quote from the Documentation[^1]
  Reset the index if it goes backwards. While indexes in general are
  monotonically increasing(i.e. they should only ever increase as time passes),
  there are several real-world scenarios in which they can go backwards for a
  given query. Implementations must check to see if a returned index is lower
  than the previous value, and if it is, should reset index to 0 - effectively
  restarting their blocking loop. Failure to do so may cause the client to miss
  future updates for an unbounded time, or to use an invalid index value that
  causes no blocking and increases load on the servers. Cases where this can
  occur include: If a raft snapshot is restored on the servers with older
  version of the data. KV list operations where an item with the highest index
  is removed. A Consul upgrade changes the way watches work to optimize them
  with more granular indexes.

[^1]: https://developer.hashicorp.com/consul/api-docs/features/blocking

---

follow-up issue to add a unit-test: https://github.com/simplesurance/grpcconsulresolver/issues/27