### PR TITLE
ci: do not run codeql for pushes to branches open as pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - "*"
+      - "master"
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
For Pull-Requests codeql ran 2x time, via the push and via the pull_request. Change the triggers to run only for pushes to the master branch.

The indentation in codeql.yml is also fixed.