### PR TITLE
Misc

### DIFF
--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sort"
 	"sync"
 	"time"
@@ -114,7 +115,7 @@ func (c *consulResolver) query(opts *consul.QueryOptions) ([]resolver.Address, u
 		}
 
 		result = append(result, resolver.Address{
-			Addr: fmt.Sprintf("%s:%d", addr, e.Service.Port),
+			Addr: net.JoinHostPort(addr, fmt.Sprint(e.Service.Port)),
 		})
 	}
 

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -249,7 +249,7 @@ func TestResolve(t *testing.T) {
 			return health, nil
 		},
 	)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	for _, tt := range tests {
 		t.Run(tt.target.URL.RequestURI(), func(t *testing.T) {
@@ -288,7 +288,7 @@ func TestResolveNewAddressOnlyCalledOnChange(t *testing.T) {
 			return health, nil
 		},
 	)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	service := []*consul.ServiceEntry{
 		{
@@ -335,7 +335,7 @@ func TestResolveAddrChange(t *testing.T) {
 			return health, nil
 		},
 	)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	services1 := []*consul.ServiceEntry{
 		{
@@ -424,7 +424,7 @@ func TestResolveAddrChangesToUnresolvable(t *testing.T) {
 			return health, nil
 		},
 	)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	services1 := []*consul.ServiceEntry{
 		{
@@ -494,7 +494,7 @@ func TestErrorIsReportedOnQueryErrors(t *testing.T) {
 			return health, nil
 		},
 	)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	cc := mocks.NewClientConn()
 	b := NewBuilder()
@@ -526,7 +526,7 @@ func TestQueryResultsAreSorted(t *testing.T) {
 			return health, nil
 		},
 	)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	health.SetRespEntries([]*consul.ServiceEntry{
 		{


### PR DESCRIPTION
```
use net.JoinHostPort to build an address string

Using net.JoinHostPort ensures that IPv6 addresses are enclosed in [] brackets.
This is required to distinguish the ":" separating parts in the ipv6 address and
":" used to specify the port.

-------------------------------------------------------------------------------
tests: use t.Cleanup instead of defer

-------------------------------------------------------------------------------
```