### PR TITLE
Establish connections to consul via https by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The default for `<consul-server>` is `127.0.0.1:8500`.
 
 | OPT        | Format                          | Default  | Description                                                                                                                                                      |
 |------------|---------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| scheme     | `http\|https`                   | http     | Establish connection to consul via http or https.                                                                                                                |
+| scheme     | `http\|https`                   | https    | Establish connection to consul via http or https.                                                                                                                |
 | tags       | `<tag>,[,<tag>]...`             |          | Filter service by tags                                                                                                                                           |
 | health     | `healthy\|fallbackToUnhealthy`  | healthy  | `healthy` resolves only to services with a passing health status.<br>`fallbackToUnhealthy` resolves to unhealthy ones if none exist with passing healthy status. |
 | token      | `string`                        |          | Add X-Consul-Token header to requests in order to authenticate against ACL                                                                                       |

--- a/consul/builder.go
+++ b/consul/builder.go
@@ -16,7 +16,7 @@
 // OPT is one of:
 //
 //   - scheme=http|https specifies if the connection to Consul is established
-//     via HTTP or HTTPS. Default: http
+//     via HTTP or HTTPS. Default: https
 //   - tags=<tag>[,<tag>]... only resolves to instances that have the given
 //     tags. Default: empty
 //   - health=healthy|fallbackToUnhealthy filters Services by their health status.
@@ -88,7 +88,7 @@ func extractOpts(opts url.Values) (scheme string, tags []string, health healthFi
 }
 
 func parseEndpoint(url *url.URL) (serviceName, scheme string, tags []string, health healthFilter, token string, err error) {
-	const defScheme = "http"
+	const defScheme = "https"
 	const defHealthFilter = healthFilterOnlyHealthy
 
 	// url.Path contains a leading "/", when the URL is in the form

--- a/consul/builder_test.go
+++ b/consul/builder_test.go
@@ -48,7 +48,7 @@ func TestParseEndpoint(t *testing.T) {
 		{
 			mustParseURL(t, "consul://localhost/user-service-rpc"),
 			"user-service-rpc",
-			"http",
+			"https",
 			nil,
 			false,
 			healthFilterOnlyHealthy,

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -63,6 +63,10 @@ func newConsulResolver(
 		WaitTime: 10 * time.Minute,
 	}
 
+	if token != "" && scheme == "http" {
+		grpclog.Warning("grpcconsulresolver: the consul api token is sent over an unencrypted connection, scheme=https should be used")
+	}
+
 	health, err := consulCreateHealthClientFn(&cfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating consul client failed. %v", err)


### PR DESCRIPTION
```
Establish connections to consul via https by default

Change the default scheme from http to https.
Since it is supported to provide an API token, this is a safer default.

-------------------------------------------------------------------------------
Log a warning message if the consul api token is sent over http

Log a warning message if a consul token was specified and an encrypted
connection is used.
This can be a security issue.

-------------------------------------------------------------------------------
```