### PR TITLE
honor CONSUL_HTTP_SSL var & document support for consul env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The default for `<consul-server>` is `127.0.0.1:8500`.
 
 | OPT        | Format                          | Default  | Description                                                                                                                                                      |
 |------------|---------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| scheme     | `http\|https`                   | http     | Establish connection to consul via http or https.                                                                                                                |
+| scheme     | `http\|https`                   |          | Establish connection to consul via http or https.                                                                                                                |
 | tags       | `<tag>,[,<tag>]...`             |          | Filter service by tags                                                                                                                                           |
 | health     | `healthy\|fallbackToUnhealthy`  | healthy  | `healthy` resolves only to services with a passing health status.<br>`fallbackToUnhealthy` resolves to unhealthy ones if none exist with passing healthy status. |
 | token      | `string`                        |          | Authenticate Consul API Request with the token.                                                                                                                  |

--- a/README.md
+++ b/README.md
@@ -19,16 +19,23 @@ following format:
 consul://[<consul-server>]/<serviceName>[?<OPT>[&<OPT>]...]
 ```
 
-The default for `<consul-server>` is `127.0.0.1:8500`.
-
 `<OPT>` is one of:
 
-| OPT        | Format                          | Default  | Description                                                                                                                                                      |
-|------------|---------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| scheme     | `http\|https`                   |          | Establish connection to consul via http or https.                                                                                                                |
-| tags       | `<tag>,[,<tag>]...`             |          | Filter service by tags                                                                                                                                           |
-| health     | `healthy\|fallbackToUnhealthy`  | healthy  | `healthy` resolves only to services with a passing health status.<br>`fallbackToUnhealthy` resolves to unhealthy ones if none exist with passing healthy status. |
-| token      | `string`                        |          | Authenticate Consul API Request with the token.                                                                                                                  |
+| OPT        | Format                          | Default                            | Description                                                                                                                                                      |
+|------------|---------------------------------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| scheme     | `http\|https`                   | default from [github.com/hashicorp/consul/api](https://pkg.go.dev/github.com/hashicorp/consul/api)   | Establish connection to consul via http or https.                                                                                                                |
+| tags       | `<tag>,[,<tag>]...`             |                                                                                                      | Filter service by tags                                                                                                                                           |
+| health     | `healthy\|fallbackToUnhealthy`  | healthy                                                                                              | `healthy` resolves only to services with a passing health status.<br>`fallbackToUnhealthy` resolves to unhealthy ones if none exist with passing healthy status. |
+| token      | `string`                        | default from [github.com/hashicorp/consul/api](https://pkg.go.dev/github.com/hashicorp/consul/api)   | Authenticate Consul API Request with the token.                                                                                                                  |
+
+If a setting is not specified in the URI, including `<consul-server>`, the
+settings defined via the standard
+[Consul Environment Variables](https://developer.hashicorp.com/consul/commands#environment-variables)
+are used. If the corresponding environment variable is also not defined, the
+defaults of the Consul Client is used. The supported environment variables and
+their default values might differ depending on the version of the used
+[github.com/hashicorp/consul/api](https://pkg.go.dev/github.com/hashicorp/consul/api)
+package.
 
 ## Example
 

--- a/consul/builder.go
+++ b/consul/builder.go
@@ -16,7 +16,7 @@
 // OPT is one of:
 //
 //   - scheme=http|https specifies if the connection to Consul is established
-//     via HTTP or HTTPS. Default: http
+//     via HTTP or HTTPS.
 //   - tags=<tag>[,<tag>]... only resolves to instances that have the given
 //     tags. Default: empty
 //   - health=healthy|fallbackToUnhealthy filters Services by their health status.
@@ -88,7 +88,6 @@ func extractOpts(opts url.Values) (scheme string, tags []string, health healthFi
 }
 
 func parseEndpoint(url *url.URL) (serviceName, scheme string, tags []string, health healthFilter, token string, err error) {
-	const defScheme = "http"
 	const defHealthFilter = healthFilterOnlyHealthy
 
 	// url.Path contains a leading "/", when the URL is in the form
@@ -101,10 +100,6 @@ func parseEndpoint(url *url.URL) (serviceName, scheme string, tags []string, hea
 	scheme, tags, health, token, err = extractOpts(url.Query())
 	if err != nil {
 		return "", "", nil, health, "", err
-	}
-
-	if scheme == "" {
-		scheme = defScheme
 	}
 
 	if health == healthFilterUndefined {

--- a/consul/builder.go
+++ b/consul/builder.go
@@ -11,8 +11,6 @@
 //
 //	consul://[<consul-server>]/<serviceName>[?<OPT>[&<OPT>]...]
 //
-// When consul-server is not specified 127.0.0.1:8500 is used.
-//
 // OPT is one of:
 //
 //   - scheme=http|https specifies if the connection to Consul is established
@@ -29,7 +27,17 @@
 // If an OPT is defined multiple times, only the value of the last occurrence
 // is used.
 //
+// The resolver can also be configured via the standard [Consul Environment Variables].
+// The supported environment variables and their defaults depend on the version
+// of the [github.com/hashicorp/consul/api] package.
+//
+// If consul-server, scheme or token is not specified in the URL, the settings
+// defined via the [Consul Environment Variables] are used. If they are not
+// defined, the defaults of the [github.com/hashicorp/consul/api.NewClient] are
+// used.
+//
 // [Blocking Consul queries]: https://developer.hashicorp.com/consul/api-docs/features/blocking
+// [Consul Environment Variables]: https://developer.hashicorp.com/consul/commands#environment-variables
 package consul
 
 import (

--- a/consul/builder_test.go
+++ b/consul/builder_test.go
@@ -48,7 +48,7 @@ func TestParseEndpoint(t *testing.T) {
 		{
 			mustParseURL(t, "consul://localhost/user-service-rpc"),
 			"user-service-rpc",
-			"http",
+			"",
 			nil,
 			false,
 			healthFilterOnlyHealthy,


### PR DESCRIPTION
```
document that resolver settings can be defined via consul env vars

The consul client is created via consul.NewClient(). This methods reads settings
from environment variables if they are not specified.
Document that the resolver can be configured via the consul environment
variables.

-------------------------------------------------------------------------------
honor CONSUL_HTTP_SSL environment variable

Instead of configuring the consul client with scheme = http, if not scheme is
provider via the query string, pass an empty scheme.
This allows to configure the scheme via the CONSUL_HTTP_SSL environment
variable, that the consul client parses if no scheme is set.

-------------------------------------------------------------------------------
```