### PR TITLE
update go & golangci-lint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 indent_size = 8
-indent_style = tabs
+indent_style = tab
 max_line_length = 80
 
 [*.go]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.18", "1.20"]
+        go: ["1.22", "1.23"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
@@ -28,7 +28,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ["1.18", "1.20"]
+        go: ["1.22", "1.23"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
@@ -47,9 +47,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.23"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51
+          version: v1.61

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,17 @@ linters:
   enable:
     - copyloopvar
     - errcheck
+    - errorlint
     - gocritic
-    - goimports
+    - godox
+    - gofumpt
     - goprintffuncname
     - gosimple
     - govet
     - ineffassign
     - misspell
     - nolintlint
+    - nosprintfhostport
     - prealloc
     - revive
     - staticcheck
@@ -21,5 +24,9 @@ linters:
     - usestdlibvars
 
 linters-settings:
-  goimports:
-    local-prefixes: github.com/simplesurance/grpcconsulresolver
+  gofumpt:
+    module-path: github.com/simplesurance/grpcconsulresolver
+    extra-rules: true
+  godox:
+    keywords:
+      - FIXME

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,13 @@
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - errcheck
-    - exportloopref
     - gocritic
     - goimports
     - goprintffuncname
     - gosimple
+    - govet
     - ineffassign
     - misspell
     - nolintlint
@@ -18,7 +19,6 @@ linters:
     - unconvert
     - unused
     - usestdlibvars
-    - vet
 
 linters-settings:
   goimports:

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/consul/api"
 	consul "github.com/hashicorp/consul/api"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/resolver"
@@ -66,7 +65,7 @@ func newConsulResolver(
 
 	health, err := consulCreateHealthClientFn(&cfg)
 	if err != nil {
-		return nil, fmt.Errorf("creating consul client failed. %v", err)
+		return nil, fmt.Errorf("creating consul client failed: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -133,7 +132,7 @@ func filterPreferOnlyHealthy(entries []*consul.ServiceEntry) []*consul.ServiceEn
 	healthy := make([]*consul.ServiceEntry, 0, len(entries))
 
 	for _, e := range entries {
-		if e.Checks.AggregatedStatus() == api.HealthPassing {
+		if e.Checks.AggregatedStatus() == consul.HealthPassing {
 			healthy = append(healthy, e)
 		}
 	}

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -254,7 +254,7 @@ func (c *consulResolver) watcher() {
 	}
 }
 
-func (c *consulResolver) ResolveNow(o resolver.ResolveNowOptions) {
+func (c *consulResolver) ResolveNow(resolver.ResolveNowOptions) {
 	select {
 	case c.resolveNow <- struct{}{}:
 

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/api"
 	consul "github.com/hashicorp/consul/api"
 	"google.golang.org/grpc/resolver"
 
@@ -97,13 +96,13 @@ func TestResolve(t *testing.T) {
 			target: resolver.Target{URL: url.URL{Path: "user-service"}},
 			consulResponse: []*consul.ServiceEntry{
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "localhost",
 						Port:    5678,
 					},
 				},
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "remotehost",
 						Port:    1234,
 					},
@@ -151,46 +150,46 @@ func TestResolve(t *testing.T) {
 			target: resolver.Target{URL: url.URL{Path: "credit-service", RawQuery: "health=fallbackToUnhealthy"}},
 			consulResponse: []*consul.ServiceEntry{
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "localhost",
 						Port:    5678,
 					},
-					Checks: api.HealthChecks{
+					Checks: consul.HealthChecks{
 						{
-							Status: api.HealthPassing,
+							Status: consul.HealthPassing,
 						},
 					},
 				},
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "remotehost",
 						Port:    9,
 					},
-					Checks: api.HealthChecks{
+					Checks: consul.HealthChecks{
 						{
-							Status: api.HealthPassing,
+							Status: consul.HealthPassing,
 						},
 					},
 				},
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "unhealthyHost",
 						Port:    1234,
 					},
-					Checks: api.HealthChecks{
+					Checks: consul.HealthChecks{
 						{
-							Status: api.HealthCritical,
+							Status: consul.HealthCritical,
 						},
 					},
 				},
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "warnedHost",
 						Port:    1,
 					},
-					Checks: api.HealthChecks{
+					Checks: consul.HealthChecks{
 						{
-							Status: api.HealthWarning,
+							Status: consul.HealthWarning,
 						},
 					},
 				},
@@ -210,24 +209,24 @@ func TestResolve(t *testing.T) {
 			target: resolver.Target{URL: url.URL{Path: "web-service", RawQuery: "health=fallbackToUnhealthy"}},
 			consulResponse: []*consul.ServiceEntry{
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "localhost",
 						Port:    5678,
 					},
-					Checks: api.HealthChecks{
+					Checks: consul.HealthChecks{
 						{
-							Status: api.HealthCritical,
+							Status: consul.HealthCritical,
 						},
 					},
 				},
 				{
-					Service: &api.AgentService{
+					Service: &consul.AgentService{
 						Address: "remotehost",
 						Port:    1234,
 					},
-					Checks: api.HealthChecks{
+					Checks: consul.HealthChecks{
 						{
-							Status: api.HealthCritical,
+							Status: consul.HealthCritical,
 						},
 					},
 				},
@@ -511,8 +510,8 @@ func TestErrorIsReportedOnQueryErrors(t *testing.T) {
 		time.Sleep(time.Millisecond)
 	}
 
-	if err != queryErr {
-		t.Fatalf("resolver error is %+v, expected %+v", err, queryErr)
+	if !errors.Is(err, queryErr) {
+		t.Fatalf("resolver error is: '%+v', expected: '%+v'", err, queryErr)
 	}
 }
 

--- a/consul/resolver_test.go
+++ b/consul/resolver_test.go
@@ -245,7 +245,7 @@ func TestResolve(t *testing.T) {
 
 	health := mocks.NewConsulHealthClient()
 	cleanup := replaceCreateHealthClientFn(
-		func(cfg *consul.Config) (consulHealthEndpoint, error) {
+		func(*consul.Config) (consulHealthEndpoint, error) {
 			return health, nil
 		},
 	)
@@ -284,7 +284,7 @@ func TestResolve(t *testing.T) {
 func TestResolveNewAddressOnlyCalledOnChange(t *testing.T) {
 	health := mocks.NewConsulHealthClient()
 	cleanup := replaceCreateHealthClientFn(
-		func(cfg *consul.Config) (consulHealthEndpoint, error) {
+		func(*consul.Config) (consulHealthEndpoint, error) {
 			return health, nil
 		},
 	)
@@ -331,7 +331,7 @@ func TestResolveNewAddressOnlyCalledOnChange(t *testing.T) {
 func TestResolveAddrChange(t *testing.T) {
 	health := mocks.NewConsulHealthClient()
 	cleanup := replaceCreateHealthClientFn(
-		func(cfg *consul.Config) (consulHealthEndpoint, error) {
+		func(*consul.Config) (consulHealthEndpoint, error) {
 			return health, nil
 		},
 	)
@@ -420,7 +420,7 @@ func TestResolveAddrChange(t *testing.T) {
 func TestResolveAddrChangesToUnresolvable(t *testing.T) {
 	health := mocks.NewConsulHealthClient()
 	cleanup := replaceCreateHealthClientFn(
-		func(cfg *consul.Config) (consulHealthEndpoint, error) {
+		func(*consul.Config) (consulHealthEndpoint, error) {
 			return health, nil
 		},
 	)
@@ -490,7 +490,7 @@ func TestErrorIsReportedOnQueryErrors(t *testing.T) {
 	health.SetRespError(queryErr)
 
 	cleanup := replaceCreateHealthClientFn(
-		func(cfg *consul.Config) (consulHealthEndpoint, error) {
+		func(*consul.Config) (consulHealthEndpoint, error) {
 			return health, nil
 		},
 	)
@@ -509,7 +509,6 @@ func TestErrorIsReportedOnQueryErrors(t *testing.T) {
 
 	for ; err == nil; err = cc.LastReportedError() {
 		time.Sleep(time.Millisecond)
-
 	}
 
 	if err != queryErr {
@@ -522,7 +521,7 @@ func TestQueryResultsAreSorted(t *testing.T) {
 	newAddressCallCnt := cc.UpdateStateCallCnt()
 	health := mocks.NewConsulHealthClient()
 	cleanup := replaceCreateHealthClientFn(
-		func(cfg *consul.Config) (consulHealthEndpoint, error) {
+		func(*consul.Config) (consulHealthEndpoint, error) {
 			return health, nil
 		},
 	)

--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-go 1.18
+go 1.22.8

--- a/internal/mocks/consulhealth.go
+++ b/internal/mocks/consulhealth.go
@@ -43,7 +43,7 @@ func (c *ConsulHealthClient) SetRespError(err error) {
 	c.err = err
 }
 
-func (c *ConsulHealthClient) ServiceMultipleTags(service string, tags []string, passingOnly bool, q *consul.QueryOptions) ([]*consul.ServiceEntry, *consul.QueryMeta, error) {
+func (c *ConsulHealthClient) ServiceMultipleTags(_ string, _ []string, _ bool, q *consul.QueryOptions) ([]*consul.ServiceEntry, *consul.QueryMeta, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 


### PR DESCRIPTION
```
golangci-lint: enable additional linters and fix found issues

Enable errorlint, godox, nosprintfhostport and gofumpt.
gofumpt replaces the goimports linter.

-------------------------------------------------------------------------------
fix: unused parameter warnings from revive linter

-------------------------------------------------------------------------------
golangci-lint: update to version 1.61

-------------------------------------------------------------------------------
go: increase minimum version to 1.22.8

-------------------------------------------------------------------------------
editorconfig: fix: invalid value for indent_style

It must be "tab" not "tabs".
```