### PR TITLE
retry resolving on errors

### DIFF
--- a/consul/backoff.go
+++ b/consul/backoff.go
@@ -1,0 +1,48 @@
+package consul
+
+import (
+	"math/rand"
+	"time"
+)
+
+type backoff struct {
+	intervals []time.Duration
+	jitterPct int
+	jitterSrc *rand.Rand
+}
+
+func defaultBackoff() *backoff {
+	return &backoff{
+		intervals: []time.Duration{
+			10 * time.Millisecond,
+			50 * time.Millisecond,
+			250 * time.Millisecond,
+			500 * time.Millisecond,
+			time.Second,
+			2 * time.Second,
+			3 * time.Second,
+			4 * time.Second,
+			5 * time.Second,
+		},
+
+		jitterPct: 10,
+		jitterSrc: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (b *backoff) Backoff(retry int) time.Duration {
+	idx := retry
+
+	if idx < 0 || idx > len(b.intervals)-1 {
+		idx = len(b.intervals) - 1
+	}
+
+	d := b.intervals[idx]
+	jitter := time.Duration((int64(d) / 100) * int64(b.jitterSrc.Intn(b.jitterPct)))
+
+	if b.jitterSrc.Intn(2) == 0 {
+		return d + jitter
+	}
+
+	return d - jitter
+}

--- a/consul/backoff_test.go
+++ b/consul/backoff_test.go
@@ -1,0 +1,36 @@
+package consul
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func minBackoff(t time.Duration, jitterPCT int) time.Duration {
+	return t - t*time.Duration(jitterPCT)/100
+}
+
+func maxBackoff(t time.Duration, jitterPCT int) time.Duration {
+	return t + t*time.Duration(jitterPCT)/100
+}
+
+func TestBackoff_IntervalIdxBounds(t *testing.T) {
+	b := defaultBackoff()
+
+	for i := range []int{-100000, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 99999999} {
+		t.Run(fmt.Sprintf("retry-%d", i), func(t *testing.T) {
+			d := b.Backoff(-10)
+
+			minB := minBackoff(b.intervals[len(b.intervals)-1], b.jitterPct)
+			maxB := maxBackoff(b.intervals[len(b.intervals)-1], b.jitterPct)
+
+			if d < minB {
+				t.Errorf("backoff is %s, expecting >%s", d, minB)
+			}
+
+			if d > maxB {
+				t.Errorf("backoff is %s, expecting <%s", d, minB)
+			}
+		})
+	}
+}

--- a/internal/mocks/consulhealth.go
+++ b/internal/mocks/consulhealth.go
@@ -7,10 +7,11 @@ import (
 )
 
 type ConsulHealthClient struct {
-	mutex     sync.Mutex
-	entries   []*consul.ServiceEntry
-	queryMeta consul.QueryMeta
-	err       error
+	mutex      sync.Mutex
+	entries    []*consul.ServiceEntry
+	queryMeta  consul.QueryMeta
+	err        error
+	resolveCnt int
 }
 
 func NewConsulHealthClient() *ConsulHealthClient {
@@ -46,10 +47,17 @@ func (c *ConsulHealthClient) SetRespError(err error) {
 func (c *ConsulHealthClient) ServiceMultipleTags(_ string, _ []string, _ bool, q *consul.QueryOptions) ([]*consul.ServiceEntry, *consul.QueryMeta, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+	c.resolveCnt++
 
 	if q.Context().Err() != nil {
 		return nil, nil, q.Context().Err()
 	}
 
 	return c.entries, &c.queryMeta, c.err
+}
+
+func (c *ConsulHealthClient) ResolveCount() int {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.resolveCnt
 }


### PR DESCRIPTION
prevent calling ReportError with the same error in a row

The resolver already prevents that UpdateState is called for the same
address multiples times in a row, do the same when reporting errors.
Only call ReportError() if the same error hasn't been reported in the
last call and UpdateState hasn't been called last.

This prevents that we unnecessary report the same state multiple times
and trigger the same events for the connection.

The code is refactored to store the last reported state in the
consulResolver struct and reporting addresses and errors is moved to
separate methods.

-------------------------------------------------------------------------------
retry resolving on errors

Some grpc-go load balancing policies, including round_robin, do not take
care about retrying resolving after an error is reported[^1].

This causes that when querying consul fails the grpc connection can hang
in a state without addresses until the connection idle timeout expires,
despite consul became reachable.

To prevent it, retry periodically querying consul when it fails.
This is done by creating a timer that calls ResolveNow() after it
expires.
The backoff implementation from commit f1f1a15 is recovered and modified
to randomize subtracting or adding the jitter from the delay, use
smaller pauses and returning the default implementation from a
constructor instead of defining it as package variable.

[^1]: https://github.com/grpc/grpc-go/issues/7729

-------------------------------------------------------------------------------


Closes: #41 

