### PR TITLE
use grpclog.Component +  fix spelling mistakes in godoc and comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ max_line_length = 80
 
 [*.go]
   indent_size = 8
-  indent_style = tabs
+  indent_style = tab
   max_line_length = 0
 
 [*.md]

--- a/consul/builder.go
+++ b/consul/builder.go
@@ -1,13 +1,13 @@
-// Package consul implements a GRPC resolver for consul service discovery.
+// Package consul implements a gRPC resolver for consul service discovery.
 // The resolver queries consul for healthy services with a specified name.
 // [Blocking Consul queries] are used to monitor Consul for changes.
 //
-// To register the resolver with the GRPC-Go library run:
+// To register the resolver with the grpc-go library run:
 //
 //	resolver.Register(consul.NewBuilder())
 //
 // Afterwards it can be used by calling [google.golang.org/grpc.Dial] and
-// passing an URL in the following format:
+// passing a URL in the following format:
 //
 //	consul://[<consul-server>]/<serviceName>[?<OPT>[&<OPT>]...]
 //

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -102,8 +102,8 @@ func (c *consulResolver) query(opts *consul.QueryOptions) ([]resolver.Address, u
 
 	result := make([]resolver.Address, 0, len(entries))
 	for _, e := range entries {
-		// when additionals fields are set in addr, addressesEqual()
-		// must be updated to honour them
+		// when additional fields are set in addr, addressesEqual()
+		// must be updated to honor them
 		addr := e.Service.Address
 		if addr == "" {
 			addr = e.Node.Address
@@ -188,9 +188,9 @@ func (c *consulResolver) watcher() {
 				}
 
 				// After ReportError() was called, the grpc
-				// loadbalancer will call ResolveNow()
+				// load balancer will call ResolveNow()
 				// periodically to retry. Therefore we do not
-				// have to retry on our own by e.g.  setting
+				// have to retry on our own by e.g. setting
 				// the timer.
 				c.cc.ReportError(err)
 				break


### PR DESCRIPTION
logging: use grpclog.Component instead of prefixing messages manually

-------------------------------------------------------------------------------
godoc, comments: fix spelling mistakes

-------------------------------------------------------------------------------
editorconfig: fix invalid indent_style for go files

It must be "tab" not "tabs.