### PR TITLE
fix: *url.Errors are not detected as equal

### DIFF
--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -283,7 +283,11 @@ func (c *consulResolver) reportAddress(addrs []resolver.Address) bool {
 }
 
 func (c *consulResolver) reportError(err error) bool {
-	if c.lastReporterState.err == err { //nolint: errorlint
+	// We compare the string representation of the errors because it is
+	// simple and works. http.Client.Do() returns [*url.Error]s which are not
+	// equal when compared with "==", neither [url.Error.Err] does because
+	// it e.g. can contain a *net.OpError.
+	if c.lastReporterState.err != nil && c.lastReporterState.err.Error() == err.Error() {
 		return false
 	}
 

--- a/internal/mocks/clientconn.go
+++ b/internal/mocks/clientconn.go
@@ -9,10 +9,11 @@ import (
 )
 
 type ClientConn struct {
-	mutex             sync.Mutex
-	addrs             []resolver.Address
-	newAddressCallCnt int
-	lastReportedError error
+	mutex              sync.Mutex
+	addrs              []resolver.Address
+	newAddressCallCnt  int
+	reportErrorCallcnt int
+	lastReportedError  error
 }
 
 func NewClientConn() *ClientConn {
@@ -27,6 +28,7 @@ func (t *ClientConn) ReportError(err error) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
+	t.reportErrorCallcnt++
 	t.lastReportedError = err
 }
 
@@ -35,6 +37,13 @@ func (t *ClientConn) LastReportedError() error {
 	defer t.mutex.Unlock()
 
 	return t.lastReportedError
+}
+
+func (t *ClientConn) ReportErrorCallCnt() int {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	return t.reportErrorCallcnt
 }
 
 func (t *ClientConn) UpdateState(state resolver.State) error {


### PR DESCRIPTION
Different instances of errors having the same struct values are unequal. That caused that *url.Errors with the same information did not evaluate as equale, compare the string represtation of the errors instead do determine equality.